### PR TITLE
ci: use GITHUB_TOKEN for GH Pages deploy

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   deploy-to-github-pages:
     runs-on: ubuntu-latest
@@ -34,8 +37,6 @@ jobs:
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          token: ${{ secrets.ACCESS_TOKEN }}
           branch: gh-pages
           folder: dist/Web/wwwroot
-          name: gh-pages
       


### PR DESCRIPTION
The previous deploy used a personal access token stored in secrets.ACCESS_TOKEN, which expired and broke the deploy step with 'Invalid username or token'.

Switch to the auto-rotated GITHUB_TOKEN by dropping the explicit token input on JamesIves/github-pages-deploy-action and granting the workflow contents:write permission. No more PAT upkeep.